### PR TITLE
NEST-501: Fixing SQL Server compatibility of the UI test, fixing that `CreateAndSetupTenantAsync` didn't throw on setup failure

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -43,7 +43,7 @@ public static class TestCaseUITestContextExtensions
             DatabaseProvider = databaseProvider,
             RequestUrlPrefix = prefix,
             RequestUrlHost = string.Empty,
-            ConnectionString = string.Empty,
+            ConnectionString = context.SqlServerRunningContext?.ConnectionString,
             TablePrefix = prefix,
             RecipeName = "Blog",
             Category = "UI Test Tenants",
@@ -53,8 +53,6 @@ public static class TestCaseUITestContextExtensions
         var setupApiModel = new TenantSetupApiModel
         {
             Name = tenantName,
-            DatabaseProvider = databaseProvider,
-            ConnectionString = string.Empty,
             RecipeName = "Blog",
             UserName = "admin",
             Email = "admin@example.com",
@@ -127,7 +125,7 @@ public static class TestCaseUITestContextExtensions
         context.Get(By.CssSelector("#RecipeName option[selected]")).Text
             .ShouldBe(createApiModel.RecipeName);
 
-        context.Get(By.CssSelector("#DatabaseProvider option[selected]")).Text
+        context.Get(By.CssSelector("#DatabaseProvider option[selected]")).GetValue()
             .ShouldBe(createApiModel.DatabaseProvider);
 
         if (createApiModel.FeatureProfiles != null)

--- a/Lombiq.OrchardCoreApiClient/ApiClient.cs
+++ b/Lombiq.OrchardCoreApiClient/ApiClient.cs
@@ -97,7 +97,8 @@ public class ApiClient<TApi> : IDisposable
 
         try
         {
-            await OrchardCoreApi.SetupAsync(setupApiViewModel).ConfigureAwait(false);
+            using var response = await OrchardCoreApi.SetupAsync(setupApiViewModel).ConfigureAwait(false);
+            await response.EnsureSuccessStatusCodeAsync();
         }
         catch (ApiException ex)
         {

--- a/Lombiq.OrchardCoreApiClient/Clients/TenantsApiClient.cs
+++ b/Lombiq.OrchardCoreApiClient/Clients/TenantsApiClient.cs
@@ -37,7 +37,8 @@ public class TenantsApiClient : ApiClient<IOrchardCoreTenantsApi>
 
         try
         {
-            await OrchardCoreApi.SetupAsync(setupApiViewModel).ConfigureAwait(false);
+            using var response = await OrchardCoreApi.SetupAsync(setupApiViewModel).ConfigureAwait(false);
+            await response.EnsureSuccessStatusCodeAsync();
         }
         catch (ApiException ex)
         {

--- a/Lombiq.OrchardCoreApiClient/Interfaces/IOrchardCoreApi.cs
+++ b/Lombiq.OrchardCoreApiClient/Interfaces/IOrchardCoreApi.cs
@@ -5,7 +5,7 @@ namespace Lombiq.OrchardCoreApiClient.Interfaces;
 /// <summary>
 /// Base interface for representing APIs of Orchard Core.
 /// </summary>
-// Keep this up-to-date with changes introduced in Orchard Core updates.
+// Keep this and the inherited interfaces up-to-date with changes introduced in Orchard Core updates.
 [SuppressMessage(
     "Design",
     "CA1040:Avoid empty interfaces",

--- a/Lombiq.OrchardCoreApiClient/Interfaces/IOrchardCoreApi.cs
+++ b/Lombiq.OrchardCoreApiClient/Interfaces/IOrchardCoreApi.cs
@@ -8,6 +8,7 @@ namespace Lombiq.OrchardCoreApiClient.Interfaces;
 /// <summary>
 /// Interface representing the subset of APIs of Orchard Core.
 /// </summary>
+// Keep this up-to-date with changes introduced in Orchard Core updates.
 public interface IOrchardCoreApi
 {
     /// <summary>


### PR DESCRIPTION
[NEST-501](https://lombiq.atlassian.net/browse/NEST-501)

[NEST-501]: https://lombiq.atlassian.net/browse/NEST-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ