### PR TITLE
OSOE-1064: Using the DefaultUser credentials when setting up the tenant during testing

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -1,6 +1,7 @@
 using Atata;
 using Lombiq.OrchardCoreApiClient.Clients;
 using Lombiq.OrchardCoreApiClient.Models;
+using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium;
@@ -59,9 +60,9 @@ public static class TestCaseUITestContextExtensions
         {
             Name = tenantName,
             RecipeName = "Blog",
-            UserName = "admin",
-            Email = "admin@example.com",
-            Password = "Password1!",
+            UserName = DefaultUser.UserName,
+            Email = DefaultUser.Email,
+            Password = DefaultUser.Password,
             SiteName = "UI Test Tenant Site",
             SiteTimeZone = "Europe/Budapest",
             TablePrefix = prefix,


### PR DESCRIPTION
[OSOE-1064](https://lombiq.atlassian.net/browse/OSOE-1064)

[OSOE-1064]: https://lombiq.atlassian.net/browse/OSOE-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ