### PR TITLE
NEST-629: Making testing tenant removal more reliable

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -374,11 +374,6 @@ public static class TestCaseUITestContextExtensions
             await context.FilterOnAdminWithSearchBoxAsync(editModel.Name);
             context.Exists(By.XPath($"//a[contains(., 'Enable') and contains(@href, '{editModel.Name}')]"));
         }
-        else
-        {
-            await context.GoToTenantLandingPageAsync(editModel.RequestUrlPrefix, editModel.RequestUrlHost);
-            context.Missing(By.ClassName("navbar-brand"));
-        }
 
         context.Configuration.TestOutputHelper.WriteLine("Disabling the tenant succeeded.");
     }
@@ -403,11 +398,6 @@ public static class TestCaseUITestContextExtensions
             await context.GoToAdminRelativeUrlAsync("/Tenants", onlyIfNotAlreadyThere: false);
             await context.FilterOnAdminWithSearchBoxAsync(editModel.Name);
             context.Missing(By.LinkText(editModel.Name));
-        }
-        else
-        {
-            await context.GoToTenantLandingPageAsync(editModel.RequestUrlPrefix, editModel.RequestUrlHost);
-            context.Missing(By.ClassName("navbar-brand"));
         }
 
         context.Configuration.TestOutputHelper.WriteLine("Removing the tenant succeeded.");

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -4,6 +4,7 @@ using Lombiq.OrchardCoreApiClient.Models;
 using Lombiq.OrchardCoreApiClient.Tests.UI.Models;
 using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Extensions;
+using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium;
 using OrchardCore.Autoroute.Models;
@@ -387,12 +388,28 @@ public static class TestCaseUITestContextExtensions
     {
         context.Configuration.TestOutputHelper.WriteLine("Removing the tenant...");
 
-        using (var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name))
-        {
-            response.Error.ShouldBeNull(
-                $"Tenant remove failed with status code {response.StatusCode}. Content: {response.Error?.Content}\n" +
-                $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
-        }
+        await ReliabilityHelper.DoWithRetriesOrFailAsync(
+            async () =>
+            {
+                var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name);
+
+                // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
+                // if it gets unstuck.
+                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
+                    response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
+                {
+                    return false;
+                }
+
+                response.Error.ShouldBeNull(
+                    $"Tenant remove failed with status code {response.StatusCode}. Content: {response.Error?.Content}\n" +
+                    $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
+
+                return true;
+            },
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(5),
+            context.Configuration.TestCancellationToken);
 
         if (checkOnAdmin)
         {

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -398,6 +398,9 @@ public static class TestCaseUITestContextExtensions
                 if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
                     response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
                 {
+                    context.Configuration.TestOutputHelper.WriteLine(
+                        "The tenant is still running, despite being disabled, and thus can't be removed. Attempting again.");
+
                     return false;
                 }
 

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -391,7 +391,7 @@ public static class TestCaseUITestContextExtensions
         await ReliabilityHelper.DoWithRetriesOrFailAsync(
             async () =>
             {
-                var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name);
+                using var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name);
 
                 // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
                 // if it gets unstuck.

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -397,7 +397,7 @@ public static class TestCaseUITestContextExtensions
                 // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
                 // if it gets unstuck.
                 if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
-                    response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
+                    response.Error?.Content?.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'.") == true)
                 {
                     context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
                         "The tenant is still running, despite being disabled, and thus can't be removed. Attempting again.");

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -81,7 +81,8 @@ public static class TestCaseUITestContextExtensions
 
         var isLocalTest = context.IsLocalUITest();
 
-        // If the RequestUrlPrefix is not empty or not set we assume we don't want to change it, so we just append "edited" to the RequestUrlHost.
+        // If the RequestUrlPrefix is not empty or not set we assume we don't want to change it, so we just append
+        // "edited" to the RequestUrlHost.
         if (string.IsNullOrEmpty(apiClientBehaviorTestModel.RequestUrlPrefix) && !isLocalTest)
         {
             editModel.RequestUrlPrefix = apiClientBehaviorTestModel.RequestUrlPrefix;

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -15,6 +15,7 @@ using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Lombiq.OrchardCoreApiClient.Tests.UI.Extensions;
 
@@ -100,7 +101,7 @@ public static class TestCaseUITestContextExtensions
         // In case of remote tests these values can be different, or coming from environment variables.
         if (isLocalTest)
         {
-            context.Configuration.TestOutputHelper.WriteLine("Using local test settings for creating tenant.");
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Using local test settings for creating tenant.");
             var databaseProvider = context.Configuration.UseSqlServer
                 ? "SqlConnection"
                 : "Sqlite";
@@ -145,7 +146,7 @@ public static class TestCaseUITestContextExtensions
         // If there are additional steps to execute in the tenant context, do that now.
         if (apiClientBehaviorTestModel.StepsInTenantContext != null)
         {
-            context.Configuration.TestOutputHelper.WriteLine("Executing additional steps in the tenant context...");
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Executing additional steps in the tenant context...");
 
             // Switch to the tenant context.
             if (string.IsNullOrEmpty(createApiModel.RequestUrlHost))
@@ -168,7 +169,7 @@ public static class TestCaseUITestContextExtensions
 
             // Switch back to the Default tenant.
             context.SwitchCurrentTenantToDefault();
-            context.Configuration.TestOutputHelper.WriteLine("Additional steps in the tenant context were done.");
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Additional steps in the tenant context were done.");
         }
 
         await TestTenantEditAsync(context, tenantsApiClient, editModel, setupApiModel, isLocalTest);
@@ -226,7 +227,7 @@ public static class TestCaseUITestContextExtensions
         TenantApiModel createApiModel,
         bool checkOnAdmin)
     {
-        context.Configuration.TestOutputHelper.WriteLine("Creating the tenant...");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Creating the tenant...");
         using (var response = await apiClient.OrchardCoreApi.CreateAsync(createApiModel))
         {
             await context.AssertLogsAsync();
@@ -234,17 +235,17 @@ public static class TestCaseUITestContextExtensions
                 $"Tenant creation failed with status code {response.StatusCode}. Content: {response.Error?.Content}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
 
-            context.Configuration.TestOutputHelper.WriteLine("Tenant creation response had no errors.");
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Tenant creation response had no errors.");
 
             // Check if response URL is valid, and visit it (should be the tenant setup page and not 404 error).
             var responseUrl = new Uri(response.Content);
-            context.Configuration.TestOutputHelper.WriteLine("Trying to go to the tenant setup page: " + responseUrl);
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Trying to go to the tenant setup page: " + responseUrl);
             await context.GoToAbsoluteUrlAsync(responseUrl);
         }
 
         if (checkOnAdmin)
         {
-            context.Configuration.TestOutputHelper.WriteLine("Asserting tenant creation on the admin page...");
+            context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Asserting tenant creation on the admin page...");
             await GoToTenantEditorAndAssertCommonTenantFieldsAsync(context, createApiModel);
 
             context.Get(By.CssSelector("#RecipeName option[selected]")).Text
@@ -263,7 +264,7 @@ public static class TestCaseUITestContextExtensions
             }
         }
 
-        context.Configuration.TestOutputHelper.WriteLine("Creating the tenant succeeded.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Creating the tenant succeeded.");
     }
 
     private static async Task TestTenantSetupAsync(
@@ -272,7 +273,7 @@ public static class TestCaseUITestContextExtensions
         TenantApiModel createApiModel,
         TenantSetupApiModel setupApiModel)
     {
-        context.Configuration.TestOutputHelper.WriteLine("Initiating tenant setup...");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Initiating tenant setup...");
         using (var response = await apiClient.OrchardCoreApi.SetupAsync(setupApiModel))
         {
             response.Error.ShouldBeNull(
@@ -280,7 +281,7 @@ public static class TestCaseUITestContextExtensions
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
         }
 
-        context.Configuration.TestOutputHelper.WriteLine("Now going to the tenant landing page to assert the setup.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Now going to the tenant landing page to assert the setup.");
 
         await context.GoToTenantLandingPageAsync(createApiModel.RequestUrlPrefix, createApiModel.RequestUrlHost);
 
@@ -289,7 +290,7 @@ public static class TestCaseUITestContextExtensions
 
         await GoToTenantUrlAndAssertHeaderAsync(context, createApiModel, setupApiModel);
 
-        context.Configuration.TestOutputHelper.WriteLine("Setting up the tenant succeeded.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Setting up the tenant succeeded.");
     }
 
     private static async Task TestTenantEditAsync(
@@ -299,7 +300,7 @@ public static class TestCaseUITestContextExtensions
         TenantSetupApiModel setupApiModel,
         bool checkOnAdmin)
     {
-        context.Configuration.TestOutputHelper.WriteLine("Editing the tenant...");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Editing the tenant...");
         using (var response = await apiClient.OrchardCoreApi.EditAsync(editModel))
         {
             response.Error.ShouldBeNull(
@@ -352,7 +353,7 @@ public static class TestCaseUITestContextExtensions
 
         await GoToTenantUrlAndAssertHeaderAsync(context, editModel, setupApiModel);
 
-        context.Configuration.TestOutputHelper.WriteLine("Editing the tenant succeeded.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Editing the tenant succeeded.");
     }
 
     private static async Task TestTenantDisableAsync(
@@ -361,7 +362,7 @@ public static class TestCaseUITestContextExtensions
         TenantApiModel editModel,
         bool checkOnAdmin)
     {
-        context.Configuration.TestOutputHelper.WriteLine("Disabling the tenant...");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Disabling the tenant...");
 
         using (var response = await apiClient.OrchardCoreApi.DisableAsync(editModel.Name))
         {
@@ -377,7 +378,7 @@ public static class TestCaseUITestContextExtensions
             context.Exists(By.XPath($"//a[contains(., 'Enable') and contains(@href, '{editModel.Name}')]"));
         }
 
-        context.Configuration.TestOutputHelper.WriteLine("Disabling the tenant succeeded.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Disabling the tenant succeeded.");
     }
 
     private static async Task TestTenantRemoveAsync(
@@ -386,7 +387,7 @@ public static class TestCaseUITestContextExtensions
         TenantApiModel editModel,
         bool checkOnAdmin)
     {
-        context.Configuration.TestOutputHelper.WriteLine("Removing the tenant...");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Removing the tenant...");
 
         await ReliabilityHelper.DoWithRetriesOrFailAsync(
             async () =>
@@ -398,7 +399,7 @@ public static class TestCaseUITestContextExtensions
                 if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
                     response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
                 {
-                    context.Configuration.TestOutputHelper.WriteLine(
+                    context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
                         "The tenant is still running, despite being disabled, and thus can't be removed. Attempting again.");
 
                     return false;
@@ -421,7 +422,7 @@ public static class TestCaseUITestContextExtensions
             context.Missing(By.LinkText(editModel.Name));
         }
 
-        context.Configuration.TestOutputHelper.WriteLine("Removing the tenant succeeded.");
+        context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Removing the tenant succeeded.");
     }
 
     private static async Task<string> TestContentCreateAsync(

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -13,7 +13,6 @@ using OrchardCore.Taxonomies.Models;
 using Shouldly;
 using System;
 using System.Linq;
-using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
@@ -390,32 +389,14 @@ public static class TestCaseUITestContextExtensions
     {
         context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Removing the tenant...");
 
-        var tryCount = 0;
-
         await ReliabilityHelper.DoWithRetriesOrFailAsync(
             async () =>
             {
-                tryCount++;
-
                 using var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name);
-
-                // For some reason the response can be null sometimes. Not clear why. We need to retry since the result
-                // can't be determined.
-                if (response == null)
-                {
-                    return false;
-                }
-
-                // A second try after a successful removal will yield a 404, which is expected. We can only get here if
-                // the first attempt was successful but yielded a null response but was successful.
-                if (tryCount > 1 && response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return true;
-                }
 
                 // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
                 // if it gets unstuck.
-                if (response.StatusCode == HttpStatusCode.BadRequest &&
+                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
                     response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
                 {
                     context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -13,6 +13,7 @@ using OrchardCore.Taxonomies.Models;
 using Shouldly;
 using System;
 using System.Linq;
+using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
@@ -389,14 +390,32 @@ public static class TestCaseUITestContextExtensions
     {
         context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Removing the tenant...");
 
+        var tryCount = 0;
+
         await ReliabilityHelper.DoWithRetriesOrFailAsync(
             async () =>
             {
+                tryCount++;
+
                 using var response = await apiClient.OrchardCoreApi.RemoveAsync(editModel.Name);
+
+                // For some reason the response can be null sometimes. Not clear why. We need to retry since the result
+                // can't be determined.
+                if (response == null)
+                {
+                    return false;
+                }
+
+                // A second try after a successful removal will yield a 404, which is expected. We can only get here if
+                // the first attempt was successful but yielded a null response but was successful.
+                if (tryCount > 1 && response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return true;
+                }
 
                 // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
                 // if it gets unstuck.
-                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
+                if (response.StatusCode == HttpStatusCode.BadRequest &&
                     response.Content.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'."))
                 {
                     context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -374,6 +374,11 @@ public static class TestCaseUITestContextExtensions
             await context.FilterOnAdminWithSearchBoxAsync(editModel.Name);
             context.Exists(By.XPath($"//a[contains(., 'Enable') and contains(@href, '{editModel.Name}')]"));
         }
+        else
+        {
+            await context.GoToTenantLandingPageAsync(editModel.RequestUrlPrefix, editModel.RequestUrlHost);
+            context.Missing(By.ClassName("navbar-brand"));
+        }
 
         context.Configuration.TestOutputHelper.WriteLine("Disabling the tenant succeeded.");
     }
@@ -398,6 +403,11 @@ public static class TestCaseUITestContextExtensions
             await context.GoToAdminRelativeUrlAsync("/Tenants", onlyIfNotAlreadyThere: false);
             await context.FilterOnAdminWithSearchBoxAsync(editModel.Name);
             context.Missing(By.LinkText(editModel.Name));
+        }
+        else
+        {
+            await context.GoToTenantLandingPageAsync(editModel.RequestUrlPrefix, editModel.RequestUrlHost);
+            context.Missing(By.ClassName("navbar-brand"));
         }
 
         context.Configuration.TestOutputHelper.WriteLine("Removing the tenant succeeded.");


### PR DESCRIPTION
[NEST-629](https://lombiq.atlassian.net/browse/NEST-629)

[NEST-629]: https://lombiq.atlassian.net/browse/NEST-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ