### PR TITLE
OSOE-1237: Removing unnecessary interpolated string usage

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -128,7 +128,7 @@ public static class TestCaseUITestContextExtensions
             await context.GoToAdminRelativeUrlAsync("/OpenId/Application");
             await context.ClickReliablyOnAsync(
                 By.XPath($"//li[contains(@class, 'list-group-item') and contains(., '{apiClientSettings.ClientId}')]" +
-                         $"//a[normalize-space(.) = 'Edit']"));
+                         "//a[normalize-space(.) = 'Edit']"));
             context.Get(By.Name("ClientId")).GetAttribute("value").ShouldBe(apiClientSettings.ClientId);
         }
         else if (isLocalTest)


### PR DESCRIPTION
[OSOE-1237](https://lombiq.atlassian.net/browse/OSOE-1237)

[OSOE-1237]: https://lombiq.atlassian.net/browse/OSOE-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ