### PR TITLE
NEST-668: Factoring out GetApiErrorContent() to a public extension method

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -10,6 +10,7 @@ using OpenQA.Selenium;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.Taxonomies.Models;
+using Refit;
 using Shouldly;
 using System;
 using System.Linq;

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -1,6 +1,5 @@
 using Atata;
 using Lombiq.OrchardCoreApiClient.Clients;
-using Lombiq.OrchardCoreApiClient.Extensions;
 using Lombiq.OrchardCoreApiClient.Models;
 using Lombiq.OrchardCoreApiClient.Tests.UI.Models;
 using Lombiq.Tests.UI.Constants;

--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -1,5 +1,6 @@
 using Atata;
 using Lombiq.OrchardCoreApiClient.Clients;
+using Lombiq.OrchardCoreApiClient.Extensions;
 using Lombiq.OrchardCoreApiClient.Models;
 using Lombiq.OrchardCoreApiClient.Tests.UI.Models;
 using Lombiq.Tests.UI.Constants;
@@ -10,7 +11,6 @@ using OpenQA.Selenium;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.Taxonomies.Models;
-using Refit;
 using Shouldly;
 using System;
 using System.Linq;
@@ -232,7 +232,7 @@ public static class TestCaseUITestContextExtensions
         {
             await context.AssertLogsAsync();
             response.Error.ShouldBeNull(
-                $"Tenant creation failed with status code {response.StatusCode}. Content: {GetApiErrorContent(response)}\n" +
+                $"Tenant creation failed with status code {response.StatusCode}. Content: {response.GetApiErrorContent()}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
 
             context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug("Tenant creation response had no errors.");
@@ -277,7 +277,7 @@ public static class TestCaseUITestContextExtensions
         using (var response = await apiClient.OrchardCoreApi.SetupAsync(setupApiModel))
         {
             response.Error.ShouldBeNull(
-                $"Tenant setup failed with status code {response.StatusCode}. Content: {GetApiErrorContent(response)}\n" +
+                $"Tenant setup failed with status code {response.StatusCode}. Content: {response.GetApiErrorContent()}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
         }
 
@@ -304,7 +304,7 @@ public static class TestCaseUITestContextExtensions
         using (var response = await apiClient.OrchardCoreApi.EditAsync(editModel))
         {
             response.Error.ShouldBeNull(
-                $"Tenant edit failed with status code {response.StatusCode}. Content: {GetApiErrorContent(response)}\n" +
+                $"Tenant edit failed with status code {response.StatusCode}. Content: {response.GetApiErrorContent()}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
         }
 
@@ -330,7 +330,7 @@ public static class TestCaseUITestContextExtensions
         using (var response = await apiClient.OrchardCoreApi.EditAsync(editModel))
         {
             response.Error.ShouldBeNull(
-                $"Tenant edit (with name change) failed with status code {response.StatusCode}. Content: {GetApiErrorContent(response)}\n" +
+                $"Tenant edit (with name change) failed with status code {response.StatusCode}. Content: {response.GetApiErrorContent()}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
         }
 
@@ -367,7 +367,7 @@ public static class TestCaseUITestContextExtensions
         using (var response = await apiClient.OrchardCoreApi.DisableAsync(editModel.Name))
         {
             response.Error.ShouldBeNull(
-                $"Tenant disable failed with status code {response.StatusCode}. Content: {GetApiErrorContent(response)}\n" +
+                $"Tenant disable failed with status code {response.StatusCode}. Content: {response.GetApiErrorContent()}\n" +
                 $"Request: {response.RequestMessage}\nDriver URL: {context.Driver.Url}");
         }
 
@@ -396,7 +396,7 @@ public static class TestCaseUITestContextExtensions
 
                 // The tenant can remain running for a while even after having been disabled. Waiting a bit here to see
                 // if it gets unstuck.
-                var errorContent = GetApiErrorContent(response);
+                var errorContent = response.GetApiErrorContent();
                 if (response.StatusCode == System.Net.HttpStatusCode.BadRequest &&
                     errorContent?.Contains($"The tenant '{editModel.Name}' should be 'Disabled' or 'Uninitialized'.") == true)
                 {
@@ -532,7 +532,4 @@ public static class TestCaseUITestContextExtensions
             DisableCertificateValidation = true,
         };
     }
-
-    private static string GetApiErrorContent(ApiResponse<string> response) =>
-        response.Error is ApiException apiException ? apiException.Content : null;
 }

--- a/Lombiq.OrchardCoreApiClient/Extensions/ApiResponseExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient/Extensions/ApiResponseExtensions.cs
@@ -1,0 +1,12 @@
+using Refit;
+
+namespace Lombiq.OrchardCoreApiClient.Extensions;
+
+public static class ApiResponseExtensions
+{
+    /// <summary>
+    /// Gets the error content from an <see cref="ApiResponse{T}"/> if the error is of type <see cref="ApiException"/>.
+    /// </summary>
+    public static string GetApiErrorContent<T>(this ApiResponse<T> response) =>
+        response.Error is ApiException apiException ? apiException.Content : null;
+}

--- a/Lombiq.OrchardCoreApiClient/Extensions/ApiResponseExtensions.cs
+++ b/Lombiq.OrchardCoreApiClient/Extensions/ApiResponseExtensions.cs
@@ -1,6 +1,4 @@
-using Refit;
-
-namespace Lombiq.OrchardCoreApiClient.Extensions;
+namespace Refit;
 
 public static class ApiResponseExtensions
 {


### PR DESCRIPTION
[NEST-668](https://lombiq.atlassian.net/browse/NEST-668)

[NEST-668]: https://lombiq.atlassian.net/browse/NEST-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ