### PR TITLE
NEST-608: Fix RequestUrlPrefix

### DIFF
--- a/Lombiq.OrchardCoreApiClient.Tests.UI/Models/ApiClientBehaviorTestModel.cs
+++ b/Lombiq.OrchardCoreApiClient.Tests.UI/Models/ApiClientBehaviorTestModel.cs
@@ -5,13 +5,11 @@ using System.Threading.Tasks;
 
 namespace Lombiq.OrchardCoreApiClient.Tests.UI.Models;
 
-public class ApiClientBehaviorTestModel
+public class ApiClientBehaviorTestModel : RequestUrlHolderBase
 {
     public string ClientId { get; set; }
     public string ClientSecret { get; set; }
     public string FeatureProfile { get; set; }
-    public string RequestUrlHost { get; set; }
-    public string RequestUrlPrefix { get; set; }
     public string TenantName { get; set; } = "UITestTenantForOrchardCoreApiClientBehavior";
     public Func<UITestContext, TenantApiModel, TenantSetupApiModel, Task> StepsInTenantContext { get; set; }
 }

--- a/Lombiq.OrchardCoreApiClient/Models/RequestUrlHolderBase.cs
+++ b/Lombiq.OrchardCoreApiClient/Models/RequestUrlHolderBase.cs
@@ -1,0 +1,13 @@
+namespace Lombiq.OrchardCoreApiClient.Models;
+
+/// <summary>
+/// Models inheriting from this contain information about the request URL.
+/// </summary>
+public abstract class RequestUrlHolderBase
+{
+    public string RequestUrlHost { get; set; }
+
+    // The setter should automatically trim leading or trailing slashes to prevent "The url prefix can not contain more
+    // than one segment." error.
+    public string RequestUrlPrefix { get; set => field = value?.Trim().Trim('/'); }
+}

--- a/Lombiq.OrchardCoreApiClient/Models/TenantApiModel.cs
+++ b/Lombiq.OrchardCoreApiClient/Models/TenantApiModel.cs
@@ -3,15 +3,13 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Lombiq.OrchardCoreApiClient.Models;
 
-public class TenantApiModel
+public class TenantApiModel : RequestUrlHolderBase
 {
     public string Description { get; set; }
 
     [Required]
     public string Name { get; set; }
     public string DatabaseProvider { get; set; }
-    public string RequestUrlPrefix { get; set; }
-    public string RequestUrlHost { get; set; }
     public string ConnectionString { get; set; }
     public string TablePrefix { get; set; }
     public string RecipeName { get; set; }


### PR DESCRIPTION
[NEST-608](https://lombiq.atlassian.net/browse/NEST-608)
to prevent \"The url prefix can not contain more than one segment.\" error

[NEST-608]: https://lombiq.atlassian.net/browse/NEST-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ